### PR TITLE
Import of the properties interface

### DIFF
--- a/projects/crystalui/angular-lightbox/src/lib/lightbox-common.component.ts
+++ b/projects/crystalui/angular-lightbox/src/lib/lightbox-common.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, HostBinding, ViewChild, ElementRef } from '@angular/core';
-import { LightboxData } from './interfaces';
+import { LightboxData, Properties } from './interfaces';
 import { ShowState, ClosingState } from './types';
 import { EventService } from './event.service';
 import { Utils } from './utils';


### PR DESCRIPTION
> Import the properties interface to avoid build errors.

Ng-packagr was importing the Properties interface directly inside the class and it was causing some build issues when I was importing the package inside my projet.

Here's the build errors : 

![erors](https://user-images.githubusercontent.com/4323797/53325485-b7915f00-38e3-11e9-9f1c-191f76ee2d29.png)

Here's how it was inside the LightboxCommonComponent :  

![before](https://user-images.githubusercontent.com/4323797/53325174-f83ca880-38e2-11e9-8a1f-aa34d04a4da3.png)

And what it looks like after the Properties import :

![after](https://user-images.githubusercontent.com/4323797/53325175-f83ca880-38e2-11e9-8e40-fd90ac73c31e.png)




